### PR TITLE
Update aemsync to 3.0.2; Add support for allowProxy and embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ module.exports = {
     {
       // name: name of the clientlib. a folder by this name will be created in destination folder.
       name: "weretail.all",
+      // allowProxy: specifies whether the clientlib should be proxied to /etc.clientlibs
+      allowProxy: true,
       // categoryName: specifiy of the clientlib to be used in content.xml (if this is not specified, then value of 'name' property would be used)
       categoryName: "weretail.all",
       // destination: specify where you want to generate the clientlib. a relative path is required.
@@ -102,6 +104,8 @@ module.exports = {
       // dependencies: comma seperated list of dependencies for this clientlib. 
       // in this case we are generating a clientlib with just CSS and it depends on weretail.all we created earlier.
       dependencies: "weretail.all",
+      // embed: comma separated list of embedded clientlibs 
+      embed: "jquery-ui",
       assets: {
         css: [
           "build/dist/css/main.rtl.css"

--- a/lib/clientlib-template-engine.js
+++ b/lib/clientlib-template-engine.js
@@ -13,8 +13,10 @@ function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj;
 var defaultTemplateStr = '<?xml version="1.0" encoding="UTF-8"?> \n\
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" \n\
     jcr:primaryType="cq:ClientLibraryFolder" \n\
+    allowProxy="<%= allowProxy %>" \n\
     categories="[<%= categoryName %>]" \n\
-    dependencies="[<%= dependencies %>]"/>';
+    dependencies="[<%= dependencies %>]" \n\
+    embed="[<%= embed %>]"/>';
 
 class ClientlibTemplateEngine {
   constructor(_templateStr, _templateSettings) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -257,8 +257,10 @@ class AEMClientLibGeneratorPlugin {
     }
     return Promise.all(_lodash2.default.map(libs, function (lib) {
       var xmlStr = templateFn({
+        allowProxy: lib.allowProxy ? 'true' : 'false',
         categoryName: typeof lib.categoryName === 'string' ? lib.categoryName : lib.name,
-        dependencies: lib.dependencies ? lib.dependencies : ''
+        dependencies: lib.dependencies ? lib.dependencies : '',
+        embed: lib.embed ? lib.embed : ''
       });
       var file = _path2.default.resolve(baseDir, lib.destination, lib.name, '.content.xml');
       var promise = _this7.options.beforeEach ? _this7.options.beforeEach : _util2.default.promisify(setImmediate);

--- a/lib/syncer.js
+++ b/lib/syncer.js
@@ -40,8 +40,13 @@ class Syncer {
   setUp() {
     var _this = this;
 
-    this.pusher = new _aemsync.Pusher(this.targets, this.pushInterval, function (err, host) {
-      _this.onPushEnd(err, host);
+    this.pusher = new _aemsync.Pipeline({
+      targets: this.targets,
+      interval: this.pushInterval,
+      packmgrPath: null,
+      onPushEnd: function onPushEnd(err, host) {
+        _this.onPushEnd(err, host);
+      }
     });
     this.pusher.start();
   }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "glob-fs": "^0.1.7"
   },
   "dependencies": {
-    "aemsync": "^2.0.1",
+    "aemsync": "^3.0.2",
     "async": "^2.6.0",
     "babel-core": "^6.26.0",
     "babel-polyfill": "^6.26.0",

--- a/src/clientlib-template-engine.js
+++ b/src/clientlib-template-engine.js
@@ -3,8 +3,10 @@ import * as _ from 'lodash';
 const defaultTemplateStr = '<?xml version="1.0" encoding="UTF-8"?> \n\
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" \n\
     jcr:primaryType="cq:ClientLibraryFolder" \n\
+    allowProxy="<%= allowProxy %>" \n\
     categories="[<%= categoryName %>]" \n\
-    dependencies="[<%= dependencies %>]"/>';
+    dependencies="[<%= dependencies %>]" \n\
+    embed="[<%= embed %>]"/>';
 
 export default class ClientlibTemplateEngine {
   constructor(_templateStr, _templateSettings) {

--- a/src/index.js
+++ b/src/index.js
@@ -184,8 +184,10 @@ export default class AEMClientLibGeneratorPlugin {
     }
     return Promise.all(_.map(libs, (lib) => {
       const xmlStr = templateFn({
+        allowProxy: lib.allowProxy ? 'true' : 'false',
         categoryName: typeof (lib.categoryName) === 'string' ? lib.categoryName : lib.name,
         dependencies: lib.dependencies ? lib.dependencies : '',
+        embed: lib.embed ? lib.embed : ''
       });
       const file = Path.resolve(baseDir, lib.destination, lib.name, '.content.xml');
       const promise = this.options.beforeEach ? this.options.beforeEach : Util.promisify(setImmediate);

--- a/src/syncer.js
+++ b/src/syncer.js
@@ -1,6 +1,6 @@
 /* eslint no-console: 0 */
 import {
-  Pusher
+  Pipeline
 } from 'aemsync';
 import 'babel-core/register';
 import 'babel-polyfill';
@@ -17,8 +17,13 @@ export default class Syncer {
     this.setUp();
   }
   setUp() {
-    this.pusher = new Pusher(this.targets, this.pushInterval, (err, host) => {
-      this.onPushEnd(err, host);
+    this.pusher = new Pipeline({
+      targets: this.targets, 
+      interval: this.pushInterval, 
+      packmgrPath: null, 
+      onPushEnd: (err, host) => {
+        this.onPushEnd(err, host);
+      }
     });
     this.pusher.start();
   }


### PR DESCRIPTION
Hi @samunplugged,

I've added support for the allowProxy and embed properties for generated ClientLibs. I've also updated the aemsync dependency to use v3.0.2 to address the vulnerabilities in its node dependencies.

Thanks in advance.